### PR TITLE
fix typo: 1MB is 0xfffff, not 0xffff which is 65535

### DIFF
--- a/Booting/linux-bootstrap-1.md
+++ b/Booting/linux-bootstrap-1.md
@@ -177,7 +177,7 @@ General real mode's memory map is:
 0x000F0000 - 0x000FFFFF - System BIOS
 ```
 
-But stop, at the beginning of post I wrote that first instruction executed by the CPU is located at address `0xfffffff0`, which is much bigger than `0xffff` (1MB). How can CPU access it in real mode? As I write about and you can read in [coreboot](http://www.coreboot.org/Developer_Manual/Memory_map) documentation:
+But stop, at the beginning of post I wrote that first instruction executed by the CPU is located at address `0xfffffff0`, which is much bigger than `0xfffff` (1MB). How can CPU access it in real mode? As I write about and you can read in [coreboot](http://www.coreboot.org/Developer_Manual/Memory_map) documentation:
 
 ```
 0xFFFE_0000 - 0xFFFF_FFFF: 128 kilobyte ROM mapped into address space

--- a/contributors.md
+++ b/contributors.md
@@ -26,3 +26,4 @@ Thank you to all contributors:
 * [George Horrell](https://github.com/georgehorrell)
 * [Ciro Santilli](https://github.com/cirosantilli)
 * [Kevin Soules](https://github.com/eax64)
+* [Fabio Pozzi](https://github.com/fabiopozzi)


### PR DESCRIPTION
fix typo in linux-bootstrap-1: 1MB is near 0xfffff, not 0xffff which is 65535