### PR TITLE
Kevinjswinton bootstrap patch

### DIFF
--- a/Booting/linux-bootstrap-1.md
+++ b/Booting/linux-bootstrap-1.md
@@ -106,8 +106,6 @@ Now the BIOS has started to work. After initializing and checking the hardware, 
 [BITS 16]
 [ORG  0x7c00]
 
-jmp boot
-
 boot:
     mov al, '!'
     mov ah, 0x0e

--- a/contributors.md
+++ b/contributors.md
@@ -27,3 +27,4 @@ Thank you to all contributors:
 * [Ciro Santilli](https://github.com/cirosantilli)
 * [Kevin Soules](https://github.com/eax64)
 * [Fabio Pozzi](https://github.com/fabiopozzi)
+* [Kevin Swinton](https://github.com/kevinjswinton)


### PR DESCRIPTION
Not an x86 expert but the **jmp boot** seems unnecessary - a quick test suggests this is the case, so I thought I'd submit this simple change (I'm working on the basis that I am correct and it is unnecessary, in which case let's remove it so as not to confuse readers, or it's actually *necessary* - in which case it'll need an *explanation*!)
