### PR TITLE
Fixed a few typos and grammar.

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -58,3 +58,4 @@ Thank you to all contributors:
 * [Maximilien Richer](https://github.com/halfa)
 * [marmeladema](https://github.com/marmeladema)
 * [Anisse Astier](https://github.com/anisse)
+* [TheCodeArtist](https://github.com/TheCodeArtist)


### PR DESCRIPTION
Fixed TYPOs and improved readability.

- Fixed common TYPOs.
- Fixed tense mismatches.
- Capitalised references to "Linux kernel" as a proper noun.
- Split run-on sentences.
- Minor changes to sentence structure to improve readability.
