### PR TITLE
fix minor typos in how_kernel_compiled.md

### DIFF
--- a/Misc/how_kernel_compiled.md
+++ b/Misc/how_kernel_compiled.md
@@ -116,7 +116,7 @@ obj		:= $(objtree)
 export srctree objtree VPATH
 ```
 
-That tells to `Makefile` that source tree of the Linux kernel will be in the current directory where `make` command was executed. After this we set `objtree` and other variables to this directory and export these variables. The next step is the getting value for the `SUBARCH` variable that will represent tewhat the underlying archicecture is:
+That tells to `Makefile` that source tree of the Linux kernel will be in the current directory where `make` command was executed. After this we set `objtree` and other variables to this directory and export these variables. The next step is the getting value for the `SUBARCH` variable that will represent what the underlying architecture is:
 
 ```Makefile
 SUBARCH := $(shell uname -m | sed -e s/i.86/x86/ -e s/x86_64/x86/ \


### PR DESCRIPTION
fix some typos I found when I read Misc/how_kernel_compiled.md.