### PR TITLE
Fix 'calll' typo in booting

### DIFF
--- a/Booting/linux-bootstrap-1.md
+++ b/Booting/linux-bootstrap-1.md
@@ -468,7 +468,7 @@ Jump to main
 That's all, we have the stack, BSS so we can jump to the `main()` C function:
 
 ```assembly
-	calll main
+	call main
 ```
 
 The `main()` function is located in [arch/x86/boot/main.c](https://github.com/torvalds/linux/blob/master/arch/x86/boot/main.c). What this does, you can read in the next part.

--- a/contributors.md
+++ b/contributors.md
@@ -78,3 +78,4 @@ Thank you to all contributors:
 * [Ruth Grace Wong](https://github.com/ruthgrace)
 * [Jeremy Lacomis](https://github.com/jlacomis)
 * [Dubyah](https://github.com/Dubyah)
+* [Martin Brugnara] (https://github.com/MartinBrugnara)


### PR DESCRIPTION
Cleaned version of #300 