### PR TITLE
Fix some mixed types in asm.md.

### DIFF
--- a/Theory/asm.md
+++ b/Theory/asm.md
@@ -307,7 +307,7 @@ a = 100
 Or for example the `I` constraint which represents a `32-bit` integer. The difference between the `i` and `I` constraints is that `i` is more general, while `I` is for strictly `32-bit` integer data. For example if you try to compile the following example:
 
 ```C
-int test_asm(int nr)
+unsigned long test_asm(int nr)
 {
         unsigned long a = 0;
 
@@ -330,7 +330,7 @@ test.c:7:9: error: impossible constraint in ‘asm’
 when:
 
 ```C
-int test_asm(int nr)
+unsigned long test_asm(int nr)
 {
         unsigned long a = 0;
 
@@ -358,7 +358,7 @@ int main(void)
         static unsigned long element;
         
         __asm__ volatile("movq 16+%1, %0" : "=r"(element) : "o"(arr));
-        printf("%d\n", element);
+        printf("%lu\n", element);
         return 0;
 }
 ```

--- a/contributors.md
+++ b/contributors.md
@@ -85,3 +85,4 @@ Thank you to all contributors:
 * [Piyush Pangtey](https://github.com/pangteypiyush)
 * [Alfred Agrell](https://github.com/Alcaro)
 * [Jakub Wilk](https://github.com/jwilk)
+* [Matthew Fernandez](https://github.com/Smattr)


### PR DESCRIPTION
This commit fixes some instances where return types did not match the type of the variable being returned or `printf` format strings did not match the types of arguments.

In the case of the return types of functions, the types silently coerce so I don't think it's a big deal, though it makes for examples that are less clear than they could be. In the case of the `printf` format argument, I think this is actually incorrect as an `int` is 4 bytes and an `unsigned long` is 8 bytes on x86_64. In practice everything's probably fine because I believe the `int` gets implicitly extended to 8 bytes by being passed through a register (as in http://blog.regehr.org/archives/1303), but I would not think this is safe in general. I realise this is all a bit IMHO and nitpicky, so if you disagree feel free to refuse this pull request.

Thanks for your work in this repo :)