### PR TITLE
Fix some missing code block end markers

### DIFF
--- a/SyncPrim/sync-4.md
+++ b/SyncPrim/sync-4.md
@@ -309,6 +309,7 @@ In all of these cases, the `__mutex_lock_common` function will acct like a `sema
 if (!mutex_is_locked(lock) &&
    (atomic_xchg_acquire(&lock->count, 0) == 1))
       goto skip_wait;
+```
 
 In a failure case the process which wants to acquire a lock will be added to the waiters list
 
@@ -354,6 +355,7 @@ void __sched mutex_unlock(struct mutex *lock)
 {
     __mutex_fastpath_unlock(&lock->count, __mutex_unlock_slowpath);
 }
+```
 
 Implementation of the `__mutex_fastpath_unlock` function is very similar to the implementation of the `__mutex_fastpath_lock` function:
 

--- a/contributors.md
+++ b/contributors.md
@@ -86,3 +86,4 @@ Thank you to all contributors:
 * [Alfred Agrell](https://github.com/Alcaro)
 * [Jakub Wilk](https://github.com/jwilk)
 * [Justus Adam](https://github.com/JustusAdam)
+* [Roy Wellington Ⅳ](https://github.com/thanatos)


### PR DESCRIPTION
Some of the code blocks in `SyncPrim/sync-4.md` were missing their end markers,
causing normal text to be added to the code block. Fix that.