### PR TITLE
Fix malformed links in SyncPrim 3 & 4 and Initialization 7.

### DIFF
--- a/Initialization/linux-initialization-7.md
+++ b/Initialization/linux-initialization-7.md
@@ -334,7 +334,7 @@ That's all, and now we can back to the `start_kernel` from the `setup_arch`.
 Back to the main.c
 ================================================================================
 
-As I wrote above, we have finished with the `setup_arch` function and now we can back to the `start_kernel` function from the [init/main.c](https://github.com/torvalds/linux/blob/master/init/main.c). As you may remember or saw yourself, `start_kernel` function as big as the `setup_arch`. So the couple of the next part will be dedicated to learning of this function. So, let's continue with it. After the `setup_arch` we can see the call of the `mm_init_cpumask` function. This function sets the [cpumask]((http://0xax.gitbooks.io/linux-insides/content/Concepts/cpumask.html)) pointer to the memory descriptor `cpumask`. We can look on its implementation:
+As I wrote above, we have finished with the `setup_arch` function and now we can back to the `start_kernel` function from the [init/main.c](https://github.com/torvalds/linux/blob/master/init/main.c). As you may remember or saw yourself, `start_kernel` function as big as the `setup_arch`. So the couple of the next part will be dedicated to learning of this function. So, let's continue with it. After the `setup_arch` we can see the call of the `mm_init_cpumask` function. This function sets the [cpumask](http://0xax.gitbooks.io/linux-insides/content/Concepts/cpumask.html) pointer to the memory descriptor `cpumask`. We can look on its implementation:
 
 ```C
 static inline void mm_init_cpumask(struct mm_struct *mm)

--- a/SyncPrim/sync-3.md
+++ b/SyncPrim/sync-3.md
@@ -4,7 +4,7 @@ Synchronization primitives in the Linux kernel. Part 3.
 Semaphores
 --------------------------------------------------------------------------------
 
-This is the third part of the [chapter](https://0xax.gitbooks.io/linux-insides/content/SyncPrim/index.html) which describes synchronization primitives in the Linux kernel and in the previous part we saw special type of [spinlocks](https://en.wikipedia.org/wiki/Spinlock) - `queued spinlocks`. The previous [part]((https://0xax.gitbooks.io/linux-insides/content/SyncPrim/sync-2.html) was the last part which describes `spinlocks` related stuff. So we need to go ahead.
+This is the third part of the [chapter](https://0xax.gitbooks.io/linux-insides/content/SyncPrim/index.html) which describes synchronization primitives in the Linux kernel and in the previous part we saw special type of [spinlocks](https://en.wikipedia.org/wiki/Spinlock) - `queued spinlocks`. The previous [part](https://0xax.gitbooks.io/linux-insides/content/SyncPrim/sync-2.html) was the last part which describes `spinlocks` related stuff. So we need to go ahead.
 
 The next [synchronization primitive](https://en.wikipedia.org/wiki/Synchronization_%28computer_science%29) after `spinlock` which we will see in this part is [semaphore](https://en.wikipedia.org/wiki/Semaphore_%28programming%29). Se will start from theoretical side and will learn what is it `semaphore` and only after this, we will see how it is implemented in the Linux kernel as we did in the previous part.
 

--- a/SyncPrim/sync-4.md
+++ b/SyncPrim/sync-4.md
@@ -13,7 +13,7 @@ So, let's start.
 Concept of `mutex`
 --------------------------------------------------------------------------------
 
-We already familiar with the [semaphore](https://en.wikipedia.org/wiki/Semaphore_%28programming%29) synchronization primitive from the previous [part]((https://0xax.gitbooks.io/linux-insides/content/SyncPrim/sync-4.html). It represented by the:
+We already familiar with the [semaphore](https://en.wikipedia.org/wiki/Semaphore_%28programming%29) synchronization primitive from the previous [part](https://0xax.gitbooks.io/linux-insides/content/SyncPrim/sync-3.html). It represented by the:
 
 ```C
 struct semaphore {

--- a/contributors.md
+++ b/contributors.md
@@ -87,3 +87,4 @@ Thank you to all contributors:
 * [Jakub Wilk](https://github.com/jwilk)
 * [Justus Adam](https://github.com/JustusAdam)
 * [Roy Wellington Ⅳ](https://github.com/thanatos)
+* [Jonathan Rennison](https://github.com/JGRennison)


### PR DESCRIPTION
'CPU mask' link in Initialization 7 is double-bracketed.
'Previous part' links in SyncPrim 3 & 4 have two opening brackets
and one closing.
'Previous part' link in SyncPrim 4 points to current page,
instead of previous.