### PR TITLE
<Theory/ELF: Fix a link to kernel memory map documentation>

### DIFF
--- a/Theory/ELF.md
+++ b/Theory/ELF.md
@@ -137,7 +137,7 @@ ELF Header:
 
 Here we can see that `vmlinux` is a 64-bit executable file.
 
-We can read from the [Documentation/x86/x86_64/mm.txt](https://github.com/torvalds/linux/blob/master/Documentation/x86/x86_64/mm.txt#L19):
+We can read from the [Documentation/x86/x86_64/mm.txt](https://github.com/torvalds/linux/blob/master/Documentation/x86/x86_64/mm.txt#L21):
 
 ```
 ffffffff80000000 - ffffffffa0000000 (=512 MB)  kernel text mapping, from phys 0


### PR DESCRIPTION
The link pointed to "EFI region mapping space" instead of "kernel text
mapping, from phys 0".

I think that the link to the mm documentation point to the wrong line.