### PR TITLE
Remove dead link

### DIFF
--- a/LINKS.md
+++ b/LINKS.md
@@ -45,10 +45,6 @@ Important data structures
 
 * [task_struct definition](http://lxr.free-electrons.com/source/include/linux/sched.h#L1274)
 
-Other architectures
-------------------------
-
-* [PowerPC and Linux Kernel Inside](http://www.systemcomputing.org/ppc/)
 
 Useful links
 ------------------------


### PR DESCRIPTION
The domain systemcomputing.org seems to be registered but there seems to be no dns
configuration. So the sites is not available.