### PR TITLE
Clarify: vDSO is linked automatically with glibc

### DIFF
--- a/SysCall/syscall-3.md
+++ b/SysCall/syscall-3.md
@@ -230,7 +230,7 @@ That's all. Now let's look on the modern concept - `vDSO`.
 Introduction to vDSO
 --------------------------------------------------------------------------------
 
-As I already wrote above, `vsyscall` is an obsolete concept and replaced by the `vDSO` or `virtual dynamic shared object`. The main difference between the `vsyscall` and `vDSO` mechanisms is that `vDSO` maps memory pages into each process in a shared object [form](https://en.wikipedia.org/wiki/Library_%28computing%29#Shared_libraries), but `vsyscall` is static in memory and has the same address every time. For the `x86_64` architecture it is called -`linux-vdso.so.1`. All userspace applications linked with this shared library via the `glibc`. For example:
+As I already wrote above, `vsyscall` is an obsolete concept and replaced by the `vDSO` or `virtual dynamic shared object`. The main difference between the `vsyscall` and `vDSO` mechanisms is that `vDSO` maps memory pages into each process in a shared object [form](https://en.wikipedia.org/wiki/Library_%28computing%29#Shared_libraries), but `vsyscall` is static in memory and has the same address every time. For the `x86_64` architecture it is called -`linux-vdso.so.1`. All userspace applications that dynamically link to `glibc` will use the `vDSO` automatically. For example:
 
 ```
 ~$ ldd /bin/uname


### PR DESCRIPTION
Change is partly a verbatim copy of https://www.kernel.org/doc/Documentation/ABI/stable/vdso

Quote: "Programs that dynamically link to glibc will use the vDSO automatically. Otherwise, you can use the reference parser in tools/testing/selftests/vDSO/parse_vdso.c."

The old version of the book was slightly imprecise. It was unclear to me whether this is an optional or a default behavior.

The main semantic change is the word 'automatically'.