### PR TITLE
Fix a description on phys_base 

### DIFF
--- a/Initialization/linux-initialization-1.md
+++ b/Initialization/linux-initialization-1.md
@@ -270,7 +270,7 @@ That's all for now. Our early paging is prepared and we just need to finish last
 Last preparation before jump at the kernel entry point
 --------------------------------------------------------------------------------
 
-After that we jump to the label `1` we enable `PAE`, `PGE` (Paging Global Extension) and put the physical address of the `phys_base` (see above) to the `rax` register and fill `cr3` register with it:
+After that we jump to the label `1` we enable `PAE`, `PGE` (Paging Global Extension) and put the content of the `phys_base` (see above) to the `rax` register and fill `cr3` register with it:
 
 ```assembly
 1:

--- a/contributors.md
+++ b/contributors.md
@@ -111,3 +111,4 @@ Thank you to all contributors:
 * [Cornelius Diekmann](https://github.com/diekmann)
 * [Andrés Rojas](https://github.com/c0r3dump3d)
 * [Beomsu Kim](https://github.com/0xF0D0)
+* [Firo Yang](https://github.com/firogh)


### PR DESCRIPTION
In the following expression, we add the value of phys_base to the
rax register, not the address of phys_base.
addq    phys_base(%rip), %rax

BTW, the value of phys_base =
the actual loaded physical address of kernel after relocation - the
likned physical address of kernel.

Signed-off-by: Firo Yang <firogh@gmail.com>