### PR TITLE
Add kernelhacking mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,24 @@ A book-in-progress about the linux kernel and its insides.
 
 **Questions/Suggestions**: Feel free about any questions or suggestions by pinging me at twitter [@0xAX](https://twitter.com/0xAX), adding an [issue](https://github.com/0xAX/linux-insides/issues/new) or just drop me an [email](mailto:anotherworldofworld@gmail.com).
 
+# Mailing List
+
+We have a Google Group mailing list for learning the kernel source code. Here are some instructions about how to use it.
+
+#### Join
+
+Send an email with any subject/content to `kernelhacking+subscribe@googlegroups.com`. Then you will receive a confirmation email. Reply it with any content and then you are done.
+
+> If you have Google account, you can also open the [archive page](https://groups.google.com/forum/#!forum/kernelhacking) and click **Apply to join group**. You will be approved automatically.
+
+#### Send emails to mailing list
+
+Just send emails to `kernelhacking@googlegroups.com`. The basic usage is the same as other mailing lists powered by mailman.
+
+#### Archives
+
+https://groups.google.com/forum/#!forum/kernelhacking
+
 Support
 -------
 


### PR DESCRIPTION
Hi, I create a Google Group mailing list to discuss the latest kernel source code. linux-insides is a good starting point to dive into the kernel code, so I think we can use this mailing list as a place to learn kernel together. Mailing list is more convenient than Issues when discuss problems and Issues can be used for ebook contribution.