### PR TITLE
Update descriptions related to initial_stack

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -120,3 +120,4 @@ Thank you to all contributors:
 * [Horace Heaven](https://github.com/horaceheaven)
 * [Miha Zidar](https://github.com/zidarsk8)
 * [Ivan Kovnatsky](https://github.com/sevenfourk)
+* [Takuya Yamamoto](https://github.com/tkyymmt)


### PR DESCRIPTION
I made these changes with reference to v4.18. Along with that, I removed obsoleted descriptions.