### PR TITLE
Use Docker to run a gitbook server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM daocloud.io/lrx0014/gitbook:master-31f4c85
+COPY ./ /srv/gitbook/
+EXPOSE 4000 35729

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM lrx0014/gitbook:3.2.3
 COPY ./ /srv/gitbook/
-EXPOSE 4000 35729
+EXPOSE 4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM daocloud.io/lrx0014/gitbook:master-31f4c85
+FROM lrx0014/gitbook:3.2.3
 COPY ./ /srv/gitbook/
 EXPOSE 4000 35729


### PR DESCRIPTION
This Dockerfile builds a simple gitbook server by docker that makes it easier to read these markdown documents in a browser. Expose port 4000 by default.