### PR TITLE
Linux initialization 1 fix

### DIFF
--- a/Initialization/linux-initialization-1.md
+++ b/Initialization/linux-initialization-1.md
@@ -125,7 +125,7 @@ where `PMD_PAGE_SIZE` macro is defined as:
 
 As we can easily calculate, `PMD_PAGE_SIZE` is `2` megabytes.
 
-If [SME](https://en.wikipedia.org/wiki/Zen_(microarchitecture)#Enhanced_security_and_virtualization_support) is supported and enabled, we activate it and include the SME encryption mask in `load_delta`:
+If [SME](https://en.wikipedia.org/wiki/Zen_%28microarchitecture%29#Enhanced_security_and_virtualization_support) is supported and enabled, we activate it and include the SME encryption mask in `load_delta`:
 
 ```C
 	sme_enable(bp);

--- a/contributors.md
+++ b/contributors.md
@@ -121,3 +121,4 @@ Thank you to all contributors:
 * [Miha Zidar](https://github.com/zidarsk8)
 * [Ivan Kovnatsky](https://github.com/sevenfourk)
 * [Takuya Yamamoto](https://github.com/tkyymmt)
+* [Dragonly](https://github.com/dragonly)


### PR DESCRIPTION
encode the parenthesis `(` -> `%28`, `)` -> `%29`, so that gitbook can parse the markdown correctly.
btw, this book helps me aloooot, thank you 0xAX!