### PR TITLE
Update linux-initialization-2.md

### DIFF
--- a/Initialization/linux-initialization-2.md
+++ b/Initialization/linux-initialization-2.md
@@ -299,7 +299,8 @@ As we may know, CPU pushes flag register, `CS` and `RIP` on the stack before cal
 | %rflags            |
 | %cs                |
 | %rip               |
-| error code         | <-- %rsp
+| error code         |
+| vector number      |<-- %rsp
 |--------------------|
 ```
 


### PR DESCRIPTION
the stack top before early_idt_handler_common execute is vector number