### PR TITLE
Minor clarity edit in sentence

### DIFF
--- a/Misc/linux-misc-3.md
+++ b/Misc/linux-misc-3.md
@@ -197,7 +197,7 @@ So, the address of the `main` function is `0000000000400506` and is offset from 
 True
 ```
 
-So we add `0x18` and `0x5` to the address of the `call` instruction. The offset is measured from the address of the following instruction. Our call instruction is 5-bytes long (`e8 18 00 00 00`) and the `0x18` is the offset of the call after the `factorial` function. A compiler generally creates each object file with the program addresses starting at zero. But if a program is created from multiple object files, these will overlap.
+So we add `0x18` and `0x5` to the address of the `call` instruction. The offset is measured from the address of the following instruction. Our call instruction is 5-bytes long (`e8 18 00 00 00`) and the `0x18` is the offset after the call instruction to the `factorial` function. A compiler generally creates each object file with the program addresses starting at zero. But if a program is created from multiple object files, these will overlap.
 
 What we have seen in this section is the `relocation` process. This process assigns load addresses to the various parts of the program, adjusting the code and data in the program to reflect the assigned addresses.
 


### PR DESCRIPTION
I may be misunderstanding the original meaning of the line, however "after the factorial function" seems to mean it would be "offset after the factorial function" (i.e. `0x400537 + 0x18`) but in reality you mean offset after the call function to get to the factorial function (`0x40051a + 0x5 + 0x18`). Very minor edit but may help for clarity. Thanks for creating such an awesome project.