### PR TITLE
Scripts/latex: Fix shellcheck warnings

### DIFF
--- a/Scripts/latex.sh
+++ b/Scripts/latex.sh
@@ -5,21 +5,23 @@
 #!/bin/bash
 rm -r build 
 mkdir build
-for D in $(ls ../); do
-    if [ -d "../${D}" ]
+for D in ../*; do
+    if [ -d "$D" ]
     then
-        echo "Converting $D . . ."
-        pandoc ../$D/README.md ../$D/linux-*.md -o build/$D.tex --template default
+        name=$(basename "$D")
+        echo "Converting $name . . ."
+        pandoc "$D"/README.md "$D"/linux-*.md \
+           -o build/"$name".tex --template default
     fi
 done
 
-cd ./build
+cd ./build || exit 1
 for f in *.tex
 do
-    pdflatex -interaction=nonstopmode $f 
+    pdflatex -interaction=nonstopmode "$f"
 done
 
-cd ../
+cd ../ || exit 1
 pandoc ../README.md ../SUMMARY.md ../CONTRIBUTING.md ../contributors.md \
    -o ./build/Preface.tex --template default
 


### PR DESCRIPTION
Shellcheck[1] gives below warnings for `latex.sh` as below.  Those are
not real problems for now, but fixing those would be helpful for future
update.  This commit therefore fixes those except the shebang position,
as the warning is for Shellcheck itself.

[1] https://www.shellcheck.net/

    $ shellcheck latex.sh
    In latex.sh line 1:
    # latex.sh
    ^-- SC2148: Tips depend on target shell and yours is unknown. Add a
    shebang.

    In latex.sh line 8:
    for D in $(ls ../); do
             ^-- SC2045: Iterating over ls output is fragile. Use globs.

    In latex.sh line 12:
            pandoc ../$D/README.md ../$D/linux-*.md -o build/$D.tex
    --template default
                      ^-- SC2086: Double quote to prevent globbing and word
    splitting.
                                      ^-- SC2086: Double quote to prevent
    globbing and word splitting.
                                                             ^-- SC2086:
    Double quote to prevent globbing and word splitting.

    In latex.sh line 16:
    cd ./build
    ^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

    In latex.sh line 19:
        pdflatex -interaction=nonstopmode $f
                                          ^-- SC2086: Double quote to
    prevent globbing and word splitting.

    In latex.sh line 22:
    cd ../
    ^-- SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

Signed-off-by: SeongJae Park <sj38.park@gmail.com>