### PR TITLE
fix: Adjust a sentence

### DIFF
--- a/Booting/linux-bootstrap-1.md
+++ b/Booting/linux-bootstrap-1.md
@@ -141,7 +141,7 @@ You will see:
 
 ![Simple bootloader which prints only `!`](images/simple_bootloader.png)
 
-In this example, we can see that the code will be executed in `16-bit` real mode. After starting, it calls the [0x10](http://www.ctyme.com/intr/rb-0106.htm) interrupt, which just prints the `!` symbol. It fills the remaining `510` bytes with zeros and finishes with the two magic bytes `0xaa` and `0x55`.
+In this example, we can see that the code will be executed in `16-bit` real mode. After starting, it calls the [0x10](http://www.ctyme.com/intr/rb-0106.htm) interrupt, which just prints the `!` symbol. The times directive will pad that number of bytes up to 510th byte with zeros and finishes with the two magic bytes `0xaa` and `0x55`.
 
 You can see a binary dump of this using the `objdump` utility:
 


### PR DESCRIPTION
The `$` symbol denotes the current address of the statement, and the `$$` denotes the address of the beginning of current section. So the lines with `times` calculate the current address in the section and subtracts it from 510. Finally, the `times` directive will pad that number of bytes up to 510th byte with zeros.