### PR TITLE
linux-datastructures-2.md: fix minor typo

### DIFF
--- a/DataStructures/linux-datastructures-2.md
+++ b/DataStructures/linux-datastructures-2.md
@@ -61,7 +61,7 @@ This structure presents the root of a radix tree and contains three fields:
 
 The first field we will discuss is `gfp_mask`:
 
-Low-level kernel memory allocation functions take a set of flags as - `gfp_mask`, which describes how that allocation is to be performed. These `GFP_` flags which control the allocation process can have following values: (`GF_NOIO` flag) means sleep and wait for memory, (`__GFP_HIGHMEM` flag) means high memory can be used, (`GFP_ATOMIC` flag) means the allocation process has high-priority and can't sleep etc.
+Low-level kernel memory allocation functions take a set of flags as - `gfp_mask`, which describes how that allocation is to be performed. These `GFP_` flags which control the allocation process can have following values: (`GFP_NOIO` flag) means sleep and wait for memory, (`__GFP_HIGHMEM` flag) means high memory can be used, (`GFP_ATOMIC` flag) means the allocation process has high-priority and can't sleep etc.
 
 * `GFP_NOIO` - can sleep and wait for memory;
 * `__GFP_HIGHMEM` - high memory can be used;


### PR DESCRIPTION
fix minor typo in linux-datastructures-2.md
fix typo: "GF_NOIO" -> "GFP_NOIO"
Signed-off-by: qinyu <chinyu0704@outlook.com>