### PR TITLE
linux-datastuctures-2.md:correct some descriptions

### DIFF
--- a/DataStructures/linux-datastructures-2.md
+++ b/DataStructures/linux-datastructures-2.md
@@ -61,11 +61,11 @@ This structure presents the root of a radix tree and contains three fields:
 
 The first field we will discuss is `gfp_mask`:
 
-Low-level kernel memory allocation functions take a set of flags as - `gfp_mask`, which describes how that allocation is to be performed. These `GFP_` flags which control the allocation process can have following values: (`GFP_NOIO` flag) means sleep and wait for memory, (`__GFP_HIGHMEM` flag) means high memory can be used, (`GFP_ATOMIC` flag) means the allocation process has high-priority and can't sleep etc.
+Low-level kernel memory allocation functions take a set of flags as - `gfp_mask`, which describes how that allocation is to be performed. These `GFP_` flags which control the allocation process can have following values: (`GFP_NOIO` flag) means allocation can block but must not initiate disk I/O; (`__GFP_HIGHMEM` flag) means either ZONE_HIGHMEM or ZONE_NORMAL memory can be used; (`GFP_ATOMIC` flag) means the allocation is high-priority and must not sleep, etc.
 
-* `GFP_NOIO` - can sleep and wait for memory;
-* `__GFP_HIGHMEM` - high memory can be used;
-* `GFP_ATOMIC` - allocation process is high-priority and can't sleep;
+* `GFP_NOIO` - allcation can block but must not initiate disk I/O;
+* `__GFP_HIGHMEM` - either ZONE_HIGHMEM or ZONE_NORMAL can be used;
+* `GFP_ATOMIC` - allocation process is high-priority and must not sleep;
 
 etc.
 


### PR DESCRIPTION
GFP_NOIO: "NOIO" is the point rather than "can't sleep"
__GFP_HIGHMEM: allocation can happens at either ZONE_NORMAL or ZONE_HIGHMEM
GFP_ATOMIC: allocation don't have to be in a "process"(e.g. in an interupt handler)

Signed-off-by: qinyu <chinyu0704@outlook.com>