### PR TITLE
Fix wrong value

### DIFF
--- a/Interrupts/linux-interrupts-8.md
+++ b/Interrupts/linux-interrupts-8.md
@@ -369,7 +369,7 @@ for the `variable_test_bit`. These two code listings starts with the same part, 
 
 After this we put this value to the `eax`, so `eax` register now contains value of the `nr`. In the end we do the same that in the first example, we put the `$268435456` (the first parameter of the `variable_test_bit` function) and the value of the `eax` (value of `nr`) to the `edi` register (the second parameter of the `variable_test_bit function`). 
 
-The next step after the `apic_intr_init` function will finish its work is the setting interrupt gates from the `FIRST_EXTERNAL_VECTOR` or `0x20` to the `0x256`:
+The next step after the `apic_intr_init` function will finish its work is the setting interrupt gates from the `FIRST_EXTERNAL_VECTOR` or `0x20` up to `0x100`:
 
 ```C
 i = FIRST_EXTERNAL_VECTOR;


### PR DESCRIPTION
NR_VECTORS is 256 if CONFIG_X86_LOCAL_APIC is not defined,
else it gets 0xec (LOCAL_TIMER_VECTOR).