### PR TITLE
fix the C bit number from 43 to 42

### DIFF
--- a/Booting/linux-bootstrap-2.md
+++ b/Booting/linux-bootstrap-2.md
@@ -127,7 +127,7 @@ As we can see the first bit(bit 43) is `0` for a _data_ segment and `1` for a _c
   * if E(bit 42) is 0, expand up, otherwise, expand down. Read more [here](http://www.sudleyplace.com/dpmione/expanddown.html).
   * if W(bit 41)(for Data Segments) is 1, write access is allowed, and if it is 0, the segment is read-only. Note that read access is always allowed on data segments.
   * A(bit 40) controls whether the segment can be accessed by the processor or not.
-  * C(bit 43) is the conforming bit(for code selectors). If C is 1, the segment code can be executed from a lower level privilege (e.g. user) level. If C is 0, it can only be executed from the same privilege level.
+  * C(bit 42) is the conforming bit(for code selectors). If C is 1, the segment code can be executed from a lower level privilege (e.g. user) level. If C is 0, it can only be executed from the same privilege level.
   * R(bit 41) controls read access to code segments; when it is 1, the segment can be read from. Write access is never granted for code segments.
 
 4. DPL[2-bits] (Descriptor Privilege Level) comprises the bits 45-46. It defines the privilege level of the segment. It can be 0-3 where 0 is the most privileged level.


### PR DESCRIPTION
I am a reader, not a linux kernel expert. I guess the number of C bit should be 42 according to the scheme of the segment descriptor.