### PR TITLE
Correct the description of check_cpu()

### DIFF
--- a/Booting/linux-bootstrap-2.md
+++ b/Booting/linux-bootstrap-2.md
@@ -358,7 +358,7 @@ if (cpu_level < req_level) {
 }
 ```
 
-The `check_cpu` function checks the CPU's flags, the presence of [long mode](http://en.wikipedia.org/wiki/Long_mode) in the case of x86_64(64-bit) CPU, checks the processor's vendor and makes preparations for certain vendors like turning off SSE+SSE2 for AMD if they are missing, etc.
+The `check_cpu` function checks the CPU's flags, the presence of [long mode](http://en.wikipedia.org/wiki/Long_mode) in the case of x86_64(64-bit) CPU, checks the processor's vendor and makes preparations for certain vendors like turning on SSE+SSE2 for AMD if they are missing, etc.
 
 at the next step, we may see a call to the `set_bios_mode` function after setup code found that a CPU is suitable. As we may see, this function is implemented only for the `x86_64` mode:
 


### PR DESCRIPTION
check_cpu() turns on SSE instructions by clearing bit 15 of HWCR MSR on legacy AMD processors. Refer to "MSRC001_0015 Hardware Configuration (HWCR)" of BIOS and Kernel Developer Guide (BKDG) for AMD Family 14h Models 00h-0Fh Processors [1].

[1] https://www.amd.com/system/files/TechDocs/43170_14h_Mod_00h-0Fh_BKDG.pdf