### PR TITLE
fix broken links on kernel stacks

### DIFF
--- a/Initialization/linux-initialization-5.md
+++ b/Initialization/linux-initialization-5.md
@@ -504,7 +504,7 @@ Links
 * [mm vs active_mm](https://www.kernel.org/doc/Documentation/vm/active_mm.txt)
 * [e820](http://en.wikipedia.org/wiki/E820)
 * [Supervisor mode access prevention](https://lwn.net/Articles/517475/)
-* [Kernel stacks](https://www.kernel.org/doc/Documentation/x86/x86_64/kernel-stacks)
+* [Kernel stacks](https://www.kernel.org/doc/Documentation/x86/kernel-stacks)
 * [TSS](http://en.wikipedia.org/wiki/Task_state_segment)
 * [IDT](http://en.wikipedia.org/wiki/Interrupt_descriptor_table)
 * [Memory mapped I/O](http://en.wikipedia.org/wiki/Memory-mapped_I/O)

--- a/Interrupts/linux-interrupts-2.md
+++ b/Interrupts/linux-interrupts-2.md
@@ -537,6 +537,6 @@ Links
 * [Union type](http://en.wikipedia.org/wiki/Union_type)
 * [this_cpu_* operations](https://github.com/torvalds/linux/blob/16f73eb02d7e1765ccab3d2018e0bd98eb93d973/Documentation/this_cpu_ops.txt)
 * [vector number](http://en.wikipedia.org/wiki/Interrupt_vector_table)
-* [Interrupt Stack Table](https://www.kernel.org/doc/Documentation/x86/x86_64/kernel-stacks)
+* [Interrupt Stack Table](https://www.kernel.org/doc/Documentation/x86/kernel-stacks)
 * [Privilege level](http://en.wikipedia.org/wiki/Privilege_level)
 * [Previous part](https://0xax.gitbook.io/linux-insides/summary/interrupts/linux-interrupts-1)

--- a/Interrupts/linux-interrupts-2.md
+++ b/Interrupts/linux-interrupts-2.md
@@ -441,7 +441,7 @@ static inline void _set_gate(int gate, unsigned type, void *addr,
 }
 ```
 
-Here we start from the `pack_gate` function which takes clean `IDT` entry represented by the `gate_desc` structure and fills it with the base address and limit, [Interrupt Stack Table](https://www.kernel.org/doc/Documentation/x86/x86_64/kernel-stacks), [Privilege level](http://en.wikipedia.org/wiki/Privilege_level), type of an interrupt which can be one of the following values:
+Here we start from the `pack_gate` function which takes clean `IDT` entry represented by the `gate_desc` structure and fills it with the base address and limit, [Interrupt Stack Table](https://www.kernel.org/doc/Documentation/x86/kernel-stacks), [Privilege level](http://en.wikipedia.org/wiki/Privilege_level), type of an interrupt which can be one of the following values:
 
 * `GATE_INTERRUPT`
 * `GATE_TRAP`

--- a/Interrupts/linux-interrupts-5.md
+++ b/Interrupts/linux-interrupts-5.md
@@ -286,7 +286,7 @@ The next exception is `#DF` or `Double fault`. This exception occurs when the pr
 set_intr_gate_ist(X86_TRAP_DF, &double_fault, DOUBLEFAULT_STACK);
 ```
 
-Note that this exception runs on the `DOUBLEFAULT_STACK` [Interrupt Stack Table](https://www.kernel.org/doc/Documentation/x86/x86_64/kernel-stacks) which has index - `1`:
+Note that this exception runs on the `DOUBLEFAULT_STACK` [Interrupt Stack Table](https://www.kernel.org/doc/Documentation/x86/kernel-stacks) which has index - `1`:
 
 ```C
 #define DOUBLEFAULT_STACK 1
@@ -485,7 +485,7 @@ Links
 * [printk](https://en.wikipedia.org/wiki/Printk)
 * [coprocessor](https://en.wikipedia.org/wiki/Coprocessor)
 * [SIMD](https://en.wikipedia.org/wiki/SIMD)
-* [Interrupt Stack Table](https://www.kernel.org/doc/Documentation/x86/x86_64/kernel-stacks)
+* [Interrupt Stack Table](https://www.kernel.org/doc/Documentation/x86/kernel-stacks)
 * [PID](https://en.wikipedia.org/wiki/Process_identifier)
 * [x87 FPU](https://en.wikipedia.org/wiki/X87)
 * [control register](https://en.wikipedia.org/wiki/Control_register)


### PR DESCRIPTION
The broken link is [old link](https://www.kernel.org/doc/Documentation/x86/kernel-stacks).  And the new link is [new link](https://www.kernel.org/doc/Documentation/x86/kernel-stacks).