### PR TITLE
Remove redundant section header in linux-bootstrap-4.md

### DIFF
--- a/Booting/linux-bootstrap-4.md
+++ b/Booting/linux-bootstrap-4.md
@@ -319,9 +319,6 @@ it has been loaded at and the compile time physical address
 
 Now that we know where to start, let's get to it.
 
-Reload the segments if needed
---------------------------------------------------------------------------------
-
 As indicated above, we start in the [arch/x86/boot/compressed/head_64.S](https://github.com/torvalds/linux/blob/16f73eb02d7e1765ccab3d2018e0bd98eb93d973/arch/x86/boot/compressed/head_64.S) assembly source code file. We first see the definition of a special section attribute before the definition of the `startup_32` function:
 
 ```assembly

--- a/contributors.md
+++ b/contributors.md
@@ -138,3 +138,4 @@ Thank you to all contributors:
 * [Dexter Plameras](https://github.com/dexterp)
 * [Jun Duan](https://github.com/waltforme)
 * [Guochao Xie](https://github.com/XieGuochao)
+* [ericlinqq](https://github.com/ericlinqq)


### PR DESCRIPTION
Remove the section header "Reload the segments if needed" as it is duplicated.