### PR TITLE
replace(Initialization/linux-initialization-1.md): sme link l:135

### DIFF
--- a/Initialization/linux-initialization-1.md
+++ b/Initialization/linux-initialization-1.md
@@ -128,7 +128,7 @@ where `PMD_PAGE_SIZE` macro is defined as:
 
 As we can easily calculate, `PMD_PAGE_SIZE` is `2` megabytes.
 
-If [SME](https://en.wikipedia.org/wiki/Zen_%28microarchitecture%29#Enhanced_security_and_virtualization_support) is supported and enabled, we activate it and include the SME encryption mask in `load_delta`:
+If [SME](https://de.wikipedia.org/wiki/Secure_Memory_Encryption) is supported and enabled, we activate it and include the SME encryption mask in `load_delta`:
 
 ```C
 	sme_enable(bp);


### PR DESCRIPTION
replaced what looked like a wrong link for SME in the first chapter on kernel initialisation