### PR TITLE
Add book.json descriptor for gitbook exporter

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,0 +1,14 @@
+{
+    "title": "Linux Insides",
+    "author" : "0xAX",
+    "pdf": {
+        "paperSize": "a5",
+        "margin":
+        {
+            "top": 48,
+            "bottom": 48,
+            "right": 28,
+            "left": 28
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for your contribution. When contributing to the project, remember to:
- Read the Contribution guide.
- Follow the Code of Conduct.
-->

**Description**

<!-- In this section, provide a description of your changes. The context and justification let others understand your motivation and the purpose of the pull request. Follow the description with a list that summarises the most relevant changes included in the pull request. -->

Changes proposed in this pull request:

Without further configuration files present in the repository, gitbook fails to find the book title and author. Furthermore, it defaults to the A4 format which is inappropriate for e-book readers. It makes the text much smaller compared to the text present in included graphics, which is stretched across the whole size of a page.

The proposed margins in conjunction with the A5 format work quire well. There are still around 10 code snippets across the whole PDF which happened to be line-wrapped, though.

The original title for the generated book was "Table of Contents". :-)