### PR TITLE
ci: Remove wrong branch name

### DIFF
--- a/.github/workflows/check-code-snippets.yaml
+++ b/.github/workflows/check-code-snippets.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 concurrency:

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
       - master
   pull_request:
 


### PR DESCRIPTION
**Description**

This PR removes the wrong branch name used in CI