### PR TITLE
ci: set default permissions for workflows

### DIFF
--- a/.github/workflows/check-code-snippets.yaml
+++ b/.github/workflows/check-code-snippets.yaml
@@ -7,6 +7,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -7,6 +7,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/generate-e-books.yaml
+++ b/.github/workflows/generate-e-books.yaml
@@ -3,6 +3,9 @@ name: Generate e-books
 on:
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   build-for-pr:
     # For every PR, build the same artifacts and make them accessible from the PR.


### PR DESCRIPTION
Add a top-level permissions block that gives the workflows only read access to the repository. Jobs that need more, like commenting on a pull request, still set their own permissions.
